### PR TITLE
Skip executing addon when Blender runs in background CLI

### DIFF
--- a/marker manager/froglet_marker_manager.py
+++ b/marker manager/froglet_marker_manager.py
@@ -11,6 +11,9 @@ bl_info = {
 }
 
 import bpy
+import sys
+if bpy.app.background:
+    sys.exit(0) # Skip executing addon when Blender runs in background CLI
 from bpy.app.handlers import persistent
 from bpy.types import Operator, AddonPreferences
 from bpy.props import StringProperty, IntProperty, BoolProperty


### PR DESCRIPTION
Skip executing the addon when Blender runs in background CLI mode (`blender -b`) to save performances and avoid potential errors due to background mode limitations.